### PR TITLE
Add Pygments to the requirements list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ docutils
 restructuredtext-lint>=0.7
 six
 stevedore
+Pygments


### PR DESCRIPTION
If you run doc8 on a sphinx source dir without sphinx installed and if
the source dir has code blocks, doc8 will throw

  D000 Cannot analyze code. Pygments package not found.

This shows up in minimized virtualenvs. It turns out you don't need
sphinx or the project in question installed to run doc8.