### PR TITLE
Allow doc8 to be called as a module

### DIFF
--- a/doc8/__main__.py
+++ b/doc8/__main__.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import sys
+
+from doc8 import main
+
+
+sys.exit(main())

--- a/doc8/main.py
+++ b/doc8/main.py
@@ -36,11 +36,6 @@ import logging
 import os
 import sys
 
-if __name__ == '__main__':
-    # Only useful for when running directly (for dev/debugging).
-    sys.path.insert(0, os.path.abspath(os.getcwd()))
-    sys.path.insert(0, os.path.abspath(os.path.join(os.pardir, os.getcwd())))
-
 import six
 from six.moves import configparser
 from stevedore import extension


### PR DESCRIPTION
Add a '__main__.py' file, which will allow us to call 'doc8' like so:

  $ python -m doc8

Some noise is removed from the 'main.py' module.

Change-Id: I6c9b2e13085c20de755d708af3ff7d047be4befd