### PR TITLE
Add pre-commit hook definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,11 @@
+---
+
+# For use with pre-commit.
+# See usage instructions at http://pre-commit.com
+
+-   id: doc8
+    name: doc8
+    description: This hook runs doc8 for linting docs
+    entry: python -m doc8
+    language: python
+    files: \.rst$


### PR DESCRIPTION
Allows user to add doc8 as a pre-commit hook.