### PR TITLE
Accept the :caption: option on code-block directives in Sphinx

### DIFF
--- a/doc8/checks.py
+++ b/doc8/checks.py
@@ -100,7 +100,10 @@ class CheckValidity(ContentCheck):
         re.compile(r"^Unknown directive type"),
         re.compile(r"^Undefined substitution"),
         re.compile(r"^Substitution definition contains illegal element"),
-        re.compile(r'^Error in \"code-block\" directive\:\nunknown option: "caption".', re.MULTILINE),
+        re.compile(
+            r'^Error in \"code-block\" directive\:\nunknown option: "caption".',
+            re.MULTILINE,
+        ),
     ]
 
     def __init__(self, cfg):

--- a/doc8/checks.py
+++ b/doc8/checks.py
@@ -100,6 +100,7 @@ class CheckValidity(ContentCheck):
         re.compile(r"^Unknown directive type"),
         re.compile(r"^Undefined substitution"),
         re.compile(r"^Substitution definition contains illegal element"),
+        re.compile(r'^Error in \"code-block\" directive\:\nunknown option: "caption".', re.MULTILINE),
     ]
 
     def __init__(self, cfg):


### PR DESCRIPTION
Sphinx allows the :caption: option on the code-block directive, but doc8 currently flags it as an error.

```restructuredtext
.. code-block:: bash
  :caption: doc8 throws an error on caption in code-blocks, even though Sphinx accepts them.

  echo "Let's fix this"
```

This pull request is to fix this.