### PR TITLE
Ignore 'label' option for 'math' directive

### DIFF
--- a/doc8/checks.py
+++ b/doc8/checks.py
@@ -103,6 +103,7 @@ class CheckValidity(ContentCheck):
         re.compile(
             r'^Error in "code-block" directive:\nunknown option: "emphasize-lines"'
         ),
+        re.compile(r'^Error in "math" directive:\nunknown option: "label"'),
     ]
 
     def __init__(self, cfg):


### PR DESCRIPTION
This is valid in Sphinx mode.

Change-Id: Ia6ab06c12bb48142995d90c1a803a739e7e92eac
Signed-off-by: Stephen Finucane <stephen@that.guru>
Fixes: #26