### PR TITLE
Accept the :substitutions: option on code-block directives in Sphinx

### DIFF
--- a/doc8/checks.py
+++ b/doc8/checks.py
@@ -109,6 +109,10 @@ class CheckValidity(ContentCheck):
         ),
         re.compile(r'^Error in "math" directive:\nunknown option: "label"'),
         re.compile(r'^Error in "math" directive:\nunknown option: "nowrap"'),
+        re.compile(
+            r'^Error in \"code-block\" directive\:\nunknown option: "substitutions".',
+            re.MULTILINE,
+        ),
     ]
 
     def __init__(self, cfg):


### PR DESCRIPTION
This fixes https://github.com/adamtheturtle/sphinx-substitution-extensions/issues/107