### PR TITLE
Turn off pre-commit's automated multiprocessing

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,3 +9,4 @@
   entry: python -m doc8
   language: python
   files: \.rst$
+  require_serial: true


### PR DESCRIPTION
Since the doc8 output includes a summary footer, this appears multiple times if pre-commit has run multiple copies of doc8 in parallel.

(This change would also be recommended if doc8 had its own multi-threading support, but I am unsure if that is the case)