### PR TITLE
Handling of Windows (and legacy Mac) line endings

### DIFF
--- a/doc8/checks.py
+++ b/doc8/checks.py
@@ -63,9 +63,6 @@ class CheckIndentationNoTab(LineCheck):
 class CheckCarriageReturn(ContentCheck):
     REPORTS = frozenset(["D004"])
 
-    def __init__(self, cfg):
-        super(CheckCarriageReturn, self).__init__(cfg)
-
     def report_iter(self, parsed_file):
         for i, line in enumerate(parsed_file.lines):
             if b"\r" in line:

--- a/doc8/checks.py
+++ b/doc8/checks.py
@@ -60,12 +60,16 @@ class CheckIndentationNoTab(LineCheck):
                 yield ("D003", "Tabulation used for indentation")
 
 
-class CheckCarriageReturn(LineCheck):
+class CheckCarriageReturn(ContentCheck):
     REPORTS = frozenset(["D004"])
 
-    def report_iter(self, line):
-        if "\r" in line:
-            yield ("D004", "Found literal carriage return")
+    def __init__(self, cfg):
+        super(CheckCarriageReturn, self).__init__(cfg)
+
+    def report_iter(self, parsed_file):
+        for i, line in enumerate(parsed_file.lines):
+            if b"\r" in line:
+                yield (i + 1, "D004", "Found literal carriage return")
 
 
 class CheckNewlineEndOfFile(ContentCheck):
@@ -75,7 +79,10 @@ class CheckNewlineEndOfFile(ContentCheck):
         super(CheckNewlineEndOfFile, self).__init__(cfg)
 
     def report_iter(self, parsed_file):
-        if parsed_file.lines and not parsed_file.lines[-1].endswith(b"\n"):
+        if parsed_file.lines and not (
+            parsed_file.lines[-1].endswith(b"\n")
+            or parsed_file._lines[-1].endswith(b"\r")
+        ):
             yield (len(parsed_file.lines), "D005", "No newline at end of file")
 
 

--- a/doc8/parser.py
+++ b/doc8/parser.py
@@ -89,8 +89,12 @@ class ParsedFile(object):
         self._read()
         for line in self._lines:
             line = str(line, encoding=self.encoding)
-            if remove_trailing_newline and line.endswith("\n"):
-                line = line[0:-1]
+            if remove_trailing_newline:
+                # Cope with various OS new line conventions
+                if line.endswith("\n"):
+                    line = line[:-1]
+                if line.endswith("\r"):
+                    line = line[:-1]
             yield line
 
     @property

--- a/doc8/parser.py
+++ b/doc8/parser.py
@@ -80,9 +80,8 @@ class ParsedFile(object):
         with self._read_lock:
             if not self._has_read:
                 with open(self.filename, "rb") as fh:
-                    self._lines = list(fh)
-                    fh.seek(0)
                     self._raw_content = fh.read()
+                    self._lines = self._raw_content.splitlines(True)
                 self._has_read = True
 
     def lines_iter(self, remove_trailing_newline=True):

--- a/doc8/tests/test_checks.py
+++ b/doc8/tests/test_checks.py
@@ -51,7 +51,7 @@ class TestCarriageReturn(testtools.TestCase):
         content = b"Windows line ending\r\nLegacy Mac line ending\r"
         content += (b"a" * 79) + b"\r\n" + b"\r"
         conf = {"max_line_length": 79}
-        with tempfile.NamedTemporaryFile as fh:
+        with tempfile.NamedTemporaryFile() as fh:
             fh.write(content)
             fh.flush()
             parsed_file = parser.ParsedFile(fh.name)


### PR DESCRIPTION
This PR addresses issue #33. 

Files with Windows line endings (CRLF, \\r\\n) raise  `D004` (Literal carriage return) errors (which is OK), but also `D002` (trailing whitespace) and they can also rise `D001` (line too long).

With this PR

- Windows and legacy Mac line endings (CRLF or CR, respectively) will still be flagged as D004 (Literal carriage return)
- but they will not be flagged as trailing whitespace (D002)
- they will not raise a "line too long" error (D001)
- and they will not raise a "No newline at end of file" (D005)

This allows users that have Windows line endings to turn off detection of `D004` and use `doc8` to check their text files.

Rationale:
The standard of a `git` installation on Windows is that line endings in text files are converted to CRLF in the local copy. There are ways, local and repository wide, to prevent that the committed files will contain CRLF (they are back-converted to LF during the commit). Unfortunately, style checkers like `doc8` check the local files, and these still contain the CRLF. This is also true when these style checkers are used within a pre-commit hook or with the software `pre-commit`.
Therefore, it is desirable for Windows users to have a way to check their files without manually converting their line endings. The proposed PR does this (Windows users can turn off the detection of `D004`) but still respects the wish of the `doc8` developers to flag non-Linux line endings in the standard settings.

This PR has manually been tested with an `.rst` file which was converted to different line endings (Linux/Window/old Mac). In case of Windows and legacy Mac line endings, each line was flagged with D004 but not other error was raised. Using `--ignore D004` let them pass without any error.
