### PR TITLE
add support for reading doc8 config from pyproject.toml file

### DIFF
--- a/doc8/main.py
+++ b/doc8/main.py
@@ -37,6 +37,7 @@ import sys
 
 try:
     import toml
+
     HAVE_TOML = True
 except ImportError:
     HAVE_TOML = False
@@ -139,13 +140,12 @@ def from_toml(fp):
 
 def extract_config(args):
     cfg = {}
-    for cfg_file in (args["config"] or CONFIG_FILENAMES):
+    for cfg_file in args["config"] or CONFIG_FILENAMES:
         if not os.path.isfile(cfg_file):
             if args["config"]:
                 print(
-                    "Configuration file %s does not exist...ignoring"
-                    % (args["config"])
-                    )
+                    "Configuration file %s does not exist...ignoring" % (args["config"])
+                )
             continue
         if cfg_file.endswith((".ini", ".cfg")):
             cfg = from_ini(cfg_file)

--- a/doc8/main.py
+++ b/doc8/main.py
@@ -35,6 +35,11 @@ import logging
 import os
 import sys
 
+try:
+    import toml
+    HAVE_TOML = True
+except ImportError:
+    HAVE_TOML = False
 
 from stevedore import extension
 
@@ -46,6 +51,8 @@ from doc8 import version
 FILE_PATTERNS = [".rst", ".txt"]
 MAX_LINE_LENGTH = 79
 CONFIG_FILENAMES = ["doc8.ini", "tox.ini", "pep8.ini", "setup.cfg"]
+if HAVE_TOML:
+    CONFIG_FILENAMES.extend(["pyproject.toml"])
 
 
 def split_set_type(text, delimiter=","):
@@ -68,19 +75,11 @@ def parse_ignore_path_errors(entries):
         ignore_path_errors[path].update(ignored_errors)
     return dict(ignore_path_errors)
 
-
-def extract_config(args):
+def from_ini(fp):
     parser = configparser.RawConfigParser()
-    read_files = []
-    if args["config"]:
-        for fn in args["config"]:
-            with open(fn, "r") as fh:
-                parser.readfp(fh, filename=fn)
-                read_files.append(fn)
-    else:
-        read_files.extend(parser.read(CONFIG_FILENAMES))
-    if not read_files:
-        return {}
+    with open(fp, "r") as fh:
+        parser.read_file(fh)
+
     cfg = {}
     try:
         cfg["max_line_length"] = parser.getint("doc8", "max-line-length")
@@ -129,6 +128,30 @@ def extract_config(args):
             cfg["extension"] = extensions
     except (configparser.NoSectionError, configparser.NoOptionError):
         pass
+    return cfg
+
+
+def from_toml(fp):
+    cfg = toml.load(fp).get("tool", {}).get("doc8", {})
+    return cfg
+
+
+def extract_config(args):
+    cfg = {}
+    for cfg_file in (args["config"] or CONFIG_FILENAMES):
+        if not os.path.isfile(cfg_file):
+            if args["config"]:
+                print(
+                    "Configuration file %s does not exist...ignoring"
+                    % (args["config"])
+                    )
+            continue
+        if cfg_file.endswith((".ini", ".cfg")):
+            cfg = from_ini(cfg_file)
+        elif cfg_file.endswith(".toml") and HAVE_TOML:
+            cfg = from_toml(cfg_file)
+        if cfg:
+            break
     return cfg
 
 

--- a/doc8/main.py
+++ b/doc8/main.py
@@ -75,6 +75,7 @@ def parse_ignore_path_errors(entries):
         ignore_path_errors[path].update(ignored_errors)
     return dict(ignore_path_errors)
 
+
 def from_ini(fp):
     parser = configparser.RawConfigParser()
     with open(fp, "r") as fh:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 mock # BSD
 nose # LGPL
 testtools # MIT
+toml # MIT


### PR DESCRIPTION
This pull request

- adds support for reading a doc8 configuration from a ``pyproject.toml`` file and
- removes deprecated function ``readfp`` by ``read_file``

Details:

- Reading from ini-files has not been changed, except for removing the deprecated function call to a non-deprecated one
- The ``pyproject.toml`` file is only taken into account if the toml package is available.
- If a configuration file is passed as argument and the path is not a file, it is ignored and warning is printed. No other configuration files are taken into account, therefore the default configuratoin is used.