### PR TITLE
Ignoring several labels for "code-block" directive.

### DIFF
--- a/doc8/checks.py
+++ b/doc8/checks.py
@@ -108,6 +108,12 @@ class CheckValidity(ContentCheck):
         re.compile(
             r'^Error in "code-block" directive:\nunknown option: "emphasize-lines"'
         ),
+        re.compile(r'^Error in "code-block" directive:\nunknown option: "linenos"'),
+        re.compile(
+            r'^Error in "code-block" directive:\nunknown option: "lineno-start"'
+        ),
+        re.compile(r'^Error in "code-block" directive:\nunknown option: "dedent"'),
+        re.compile(r'^Error in "code-block" directive:\nunknown option: "force"'),
         re.compile(r'^Error in "math" directive:\nunknown option: "label"'),
         re.compile(r'^Error in "math" directive:\nunknown option: "nowrap"'),
         re.compile(


### PR DESCRIPTION
There are several options in the "code-block" which are valid in Sphinx: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html?highlight=linenos#directive-code-block.

This should resolve all of the issues in #30. 