### PR TITLE
Clarify pyproject.toml configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ instead.
 * ``$CWD/tox.ini``
 * ``$CWD/pep8.ini``
 * ``$CWD/setup.cfg``
-* ``$CWD/pyproject.toml``
+* ``$CWD/pyproject.toml`` in section ``[tool.doc8]`` if ``toml`` is installed
 
 An example section that can be placed into one of these files::
 


### PR DESCRIPTION
Hi, just for clarity I thought the pyproject configuration spec could be more verbose. This PR adds info on the assumed configuration section and the fact that the `toml` library needs to be installed.