### PR TITLE
setup.cfg: Replace dash-separated options

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ author = OpenStack
 author_email = openstack-discuss@lists.openstack.org
 maintainer = PyCQA
 maintainer_email = code-quality@python.org
-home-page = https://github.com/pycqa/doc8
+home_page = https://github.com/pycqa/doc8
 long_description_content_type = text/x-rst
 classifier =
     Intended Audience :: Information Technology
@@ -30,12 +30,12 @@ console_scripts =
 
 [flake8]
 builtins = _
-show-source = True
+show_source = True
 exclude=.venv,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*egg,build
 # Minimal config needed to make flake8 compatible with black output:
-max-line-length=160
+max_line_length=160
 # See https://github.com/PyCQA/pycodestyle/issues/373
-extend-ignore = E203
+extend_ignore = E203
 
 [options]
 python_requires = >=3.6


### PR DESCRIPTION
Recent versions of setuptools report that options with names separated
by a dash (e.g. 'home-page') are deprecated and support will be
removed in later versions.