### PR TITLE
Use tomli to read .toml files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,6 @@ repos:
           - types-mock
           - types-setuptools
           - types-docutils
-          - types-toml
   - repo: https://github.com/PyCQA/pylint
     rev: v2.13.3
     hooks:

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ instead.
 * ``$CWD/tox.ini``
 * ``$CWD/pep8.ini``
 * ``$CWD/setup.cfg``
-* ``$CWD/pyproject.toml`` in section ``[tool.doc8]`` if ``toml`` is installed
+* ``$CWD/pyproject.toml`` in section ``[tool.doc8]`` if ``tomli`` is installed
 
 An example section that can be placed into one of these files::
 

--- a/src/doc8/main.py
+++ b/src/doc8/main.py
@@ -36,7 +36,7 @@ import os
 import sys
 
 try:
-    import toml
+    import tomli
 
     HAVE_TOML = True
 except ImportError:
@@ -134,7 +134,8 @@ def from_ini(fp):
 
 
 def from_toml(fp):
-    cfg = toml.load(fp).get("tool", {}).get("doc8", {})
+    with open(fp, "rb") as f:
+        cfg = tomli.load(f).get("tool", {}).get("doc8", {})
     return cfg
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 mock # BSD
 pytest # MIT
-toml # MIT
+tomli # MIT


### PR DESCRIPTION
Replace the use of the `toml` package with `tomli`.  The `toml` package
is no longer maintained and does not support TOML 1.0.