### PR TITLE
Make toml support implicit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ instead.
 * ``$CWD/tox.ini``
 * ``$CWD/pep8.ini``
 * ``$CWD/setup.cfg``
-* ``$CWD/pyproject.toml`` in section ``[tool.doc8]`` if ``tomli`` is installed or when using a Python version greater or equal than 3.11
+* ``$CWD/pyproject.toml``
 
 An example section that can be placed into one of these files::
 

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ instead.
 * ``$CWD/tox.ini``
 * ``$CWD/pep8.ini``
 * ``$CWD/setup.cfg``
-* ``$CWD/pyproject.toml`` in section ``[tool.doc8]`` if ``tomli`` is installed
+* ``$CWD/pyproject.toml`` in section ``[tool.doc8]`` if ``tomli`` is installed or when using a Python version greater or equal than 3.11
 
 An example section that can be placed into one of these files::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ install_requires =
     docutils
     restructuredtext-lint>=0.7
     stevedore
+    tomli; python_version < '3.11'
     Pygments
 
 [options.entry_points]

--- a/src/doc8/main.py
+++ b/src/doc8/main.py
@@ -31,16 +31,20 @@ What is checked:
 import argparse
 import collections
 import configparser
+import importlib
 import logging
 import os
 import sys
 
-try:
-    import tomli
 
-    HAVE_TOML = True
-except ImportError:
-    HAVE_TOML = False
+HAVE_TOML = False
+for module_name in ("tomllib", "tomli"):
+    try:
+        toml_module = importlib.import_module(module_name)
+        HAVE_TOML = True
+        break
+    except ModuleNotFoundError:
+        pass
 
 from stevedore import extension
 
@@ -135,7 +139,7 @@ def from_ini(fp):
 
 def from_toml(fp):
     with open(fp, "rb") as f:
-        parsed = tomli.load(f).get("tool", {}).get("doc8", {})
+        parsed = toml_module.load(f).get("tool", {}).get("doc8", {})
 
     cfg = {}
     for key, value in parsed.items():


### PR DESCRIPTION
Starting with 3.11 Python has a build-in library for parsing TOML, called `tomllib`. With this PR, tomli no longer needs to be installed when using python 3.11 to parse a pyproject.toml.