### PR TITLE
Remove pip from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
-  "pip >= 19.3.1",
   "setuptools >= 42",
   "setuptools_scm[toml] >= 3.5.0",
   "setuptools_scm_git_archive >= 1.1",


### PR DESCRIPTION
In response to https://github.com/PyCQA/doc8/issues/91#issuecomment-1195509689