### PR TITLE
fix: update action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Publish to test.pypi.org
       if: >-  # "create" workflows run separately from "push" & "pull_request"
         github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@v1.5.1
       with:
         password: ${{ secrets.testpypi_password }}
         repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Refs: #124

Since the workflow only triggers on published release, this code won't be exercised until the next release.

Must have been missed when #111 did the same for a few lines below.