### PR TITLE
Clean up build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,6 @@
 requires = [
   "setuptools>=61.2",
   "setuptools_scm[toml] >= 3.5.0",
-  "setuptools_scm_git_archive >= 1.1",
-  "wheel >= 0.33.6",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
I think these two dependencies do not need to be specified in pyproject.toml:

1. setuptools_scm_git_archive does not seem to be needed unless a .git_archival.txt file exists
2. wheel does not need to be specified: setuptools defines a get_requires_for_build_wheel function in its build backend that does this automatically