### PR TITLE
Fix absolute paths not considered for `ignore-path-errors` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ coverage.xml
 # Sphinx documentation
 doc/build/
 src/doc8/_version.py
+
+# IDE caches
+.idea/
+.vscode/

--- a/src/doc8/main.py
+++ b/src/doc8/main.py
@@ -230,6 +230,10 @@ def validate(cfg, files, result=None):
     error_counts = {}
     ignoreables = frozenset(cfg.get("ignore", []))
     ignore_targeted = cfg.get("ignore_path_errors", {})
+    ignore_targeted = {
+        os.path.abspath(file_path): ignore_codes
+        for file_path, ignore_codes in ignore_targeted.items()
+    }
     while files:
         f = files.popleft()
         if cfg.get("verbose"):


### PR DESCRIPTION
fixes #147