### PR TITLE
Add example for pyproject.toml config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,14 @@ An example section that can be placed into one of these files::
     verbose=1
     ignore-path-errors=/tmp/other_thing.rst;D001;D002
 
+
+An example for the ``pyproject.toml`` file:
+
+    [tool.doc8]
+
+    ignore = ["D001"]
+    allow-long-titles = true
+
 **Note:** The option names are the same as the command line ones (with the
 only variation of this being the ``no-sphinx`` option which from the
 configuration file will be ``sphinx`` instead).

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ An example section that can be placed into one of these files::
     ignore-path-errors=/tmp/other_thing.rst;D001;D002
 
 
-An example for the ``pyproject.toml`` file:
+An example for the ``pyproject.toml`` file::
 
     [tool.doc8]
 


### PR DESCRIPTION
As the syntax differs from the .ini files it is helpful to also add an example for pyproject.toml files.
Also see https://github.com/PyCQA/doc8/issues/145#issuecomment-1944129330