### PR TITLE
bump docutils support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires-python = ">=3.8"
 dependencies = [
     # Ceiled due to DeprecationWarning: The frontend.OptionParser class will be
     # replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
-    "docutils>=0.19,<0.21",
+    "docutils>=0.19,<=0.21.2",
     "restructuredtext-lint>=0.7",
     "stevedore",
     "tomli; python_version < '3.11'",


### PR DESCRIPTION
docutils 0.21.2 still emits the relevant deprecation warnings, but has not removed the classes.