### PR TITLE
Check for indentation of 3 spaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,67 +32,70 @@ Quick start
 
 ::
 
-    pip install doc8
+   pip install doc8
+
 
 To run *doc8*, just invoke it against any documentation directory::
 
-    $ doc8 cool-project/docs
+   $ doc8 cool-project/docs
 
 Usage
 -----
 
 ::
 
-    $ doc8  -h
+   $ doc8  -h
+   usage: doc8 [-h] [--config path] [--allow-long-titles] [--ignore code]
+               [--no-sphinx] [--ignore-path path] [--ignore-path-errors path]
+               [--default-extension extension] [--file-encoding encoding]
+               [--max-line-length int] [-e extension] [-q] [-v] [--version]
+               [path ...]
 
-    usage: doc8 [-h] [--config path] [--allow-long-titles] [--ignore code]
-                [--no-sphinx] [--ignore-path path] [--ignore-path-errors path]
-                [--default-extension extension] [--file-encoding encoding]
-                [--max-line-length int] [-e extension] [-v] [--version]
-                [path [path ...]]
+   Check documentation for simple style requirements.
 
-    Check documentation for simple style requirements.
+   What is checked:
+      -  invalid RST format - D000
+      -  lines should not be longer than 79 characters - D001
+         -  RST exception: line with no whitespace except in the beginning
+         -  RST exception: lines with http or https urls
+         -  RST exception: literal blocks
+         -  RST exception: rst target directives
+      -  no trailing whitespace - D002
+      -  no tabulation for indentation - D003
+         -  All RST files use an indentation of 3 spaces
+      -  no carriage returns (use unix newlines) - D004
+      -  no newline at end of file - D005
 
-    What is checked:
-        - invalid RST format - D000
-        - lines should not be longer than 79 characters - D001
-          - RST exception: line with no whitespace except in the beginning
-          - RST exception: lines with http or https urls
-          - RST exception: literal blocks
-          - RST exception: rst target directives
-        - no trailing whitespace - D002
-        - no tabulation for indentation - D003
-        - no carriage returns (use unix newlines) - D004
-        - no newline at end of file - D005
+   positional arguments:
+     path                  path to scan for doc files (default: current
+                           directory).
 
-    positional arguments:
-      path                  Path to scan for doc files (default: current
-                            directory).
-
-    optional arguments:
-      -h, --help            show this help message and exit
-      --config path         user config file location (default: .config/doc8.ini, doc8.ini, tox.ini,
-                            pep8.ini, setup.cfg).
-      --allow-long-titles   allow long section titles (default: false).
-      --ignore code         ignore the given error code(s).
-      --no-sphinx           do not ignore sphinx specific false positives.
-      --ignore-path path    ignore the given directory or file (globs are
-                            supported).
-      --ignore-path-errors path
-                            ignore the given specific errors in the provided file.
-      --default-extension extension
-                            default file extension to use when a file is found
-                            without a file extension.
-      --file-encoding encoding
-                            set input files text encoding
-      --max-line-length int
-                            maximum allowed line length (default: 79).
-      -e extension, --extension extension
-                            check file extensions of the given type (default:
-                            .rst, .txt).
-      -q, --quiet           only print violations
-      -v, --verbose         run in verbose mode.
-      --version             show the version and exit.
+   options:
+     -h, --help            show this help message and exit
+     --config path         user config file location (default: doc8.ini,
+                           .config/doc8.ini, tox.ini, pep8.ini, setup.cfg,
+                           pyproject.toml).
+     --allow-long-titles   allow long section titles (default: false).
+     --ignore code         ignore the given error code(s).
+     --no-sphinx           do not ignore sphinx specific false positives.
+     --ignore-path path    ignore the given directory or file (globs are
+                           supported).
+     --ignore-path-errors path
+                           ignore the given specific errors in the provided
+                           file.
+     --default-extension extension
+                           default file extension to use when a file is found
+                           without a file extension.
+     --file-encoding encoding
+                           set input files text encoding
+     --max-line-length int
+                           maximum allowed line length (default: 79).
+     -e, --extension extension
+                           check file extensions of the given type (default:
+                           .rst, .txt).
+     -q, --quiet           only print violations
+     -v, --verbose         run in verbose mode.
+     --version             show the version and exit.
 
 INI file usage
 ~~~~~~~~~~~~~~
@@ -103,29 +106,29 @@ the ``--config path`` option is used, these files will **not** be scanned for
 the current working directory and that configuration path will be used
 instead.
 
-* ``$CWD/doc8.ini``
-* ``$CWD/.config/doc8.ini``
-* ``$CWD/tox.ini``
-* ``$CWD/pep8.ini``
-* ``$CWD/setup.cfg``
-* ``$CWD/pyproject.toml``
+*  ``$CWD/doc8.ini``
+*  ``$CWD/.config/doc8.ini``
+*  ``$CWD/tox.ini``
+*  ``$CWD/pep8.ini``
+*  ``$CWD/setup.cfg``
+*  ``$CWD/pyproject.toml``
 
 An example section that can be placed into one of these files::
 
-    [doc8]
+   [doc8]
 
-    ignore-path=/tmp/stuff,/tmp/other_stuff
-    max-line-length=99
-    verbose=1
-    ignore-path-errors=/tmp/other_thing.rst;D001;D002
+   ignore-path=/tmp/stuff,/tmp/other_stuff
+   max-line-length=99
+   verbose=1
+   ignore-path-errors=/tmp/other_thing.rst;D001;D002
 
 
 An example for the ``pyproject.toml`` file::
 
-    [tool.doc8]
+   [tool.doc8]
 
-    ignore = ["D001"]
-    allow-long-titles = true
+   ignore = ["D001"]
+   allow-long-titles = true
 
 **Note:** The option names are the same as the command line ones (with the
 only variation of this being the ``no-sphinx`` option which from the
@@ -165,19 +168,19 @@ API
 It is also possible to use *doc8* programmatically. To call *doc8* from a
 Python project, use::
 
-    from doc8 import doc8
+   from doc8 import doc8
 
-    result = doc8(allow_long_titles=True, max_line_length=99)
+   result = doc8(allow_long_titles=True, max_line_length=99)
 
 The returned ``result`` will have the following attributes and methods:
 
-* ``result.files_selected`` - number of files selected
-* ``result.files_ignored`` - number of files ignored
-* ``result.error_counts`` - ``dict`` of ``{check_name: error_count}``
-* ``result.total_errors`` - total number of errors found
-* ``result.errors`` - list of
-  ``(check_name, filename, line_num, code, message)`` tuples
-* ``result.report()`` - returns a human-readable report as a string
+*  ``result.files_selected`` - number of files selected
+*  ``result.files_ignored`` - number of files ignored
+*  ``result.error_counts`` - ``dict`` of ``{check_name: error_count}``
+*  ``result.total_errors`` - total number of errors found
+*  ``result.errors`` - list of
+   ``(check_name, filename, line_num, code, message)`` tuples
+*  ``result.report()`` - returns a human-readable report as a string
 
 The ``doc8`` method accepts the same arguments as the executable. Simply
 replace hyphens with underscores.

--- a/src/doc8/checks.py
+++ b/src/doc8/checks.py
@@ -48,7 +48,7 @@ class CheckTrailingWhitespace(LineCheck):
             yield ("D002", "Trailing whitespace")
 
 
-class CheckIndentationNoTab(LineCheck):
+class CheckIndentation(LineCheck):
     _STARTING_WHITESPACE_REGEX = re.compile(r"^(\s+)")
     REPORTS = frozenset(["D003"])
 
@@ -58,6 +58,8 @@ class CheckIndentationNoTab(LineCheck):
             spaces = match.group(1)
             if "\t" in spaces:
                 yield ("D003", "Tabulation used for indentation")
+            elif " " in spaces and len(spaces) % 3:
+                yield ("D003", "All RST files use an indentation of 3 spaces")
 
 
 class CheckCarriageReturn(ContentCheck):

--- a/src/doc8/main.py
+++ b/src/doc8/main.py
@@ -16,16 +16,17 @@
 """Check documentation for simple style requirements.
 
 What is checked:
-    - invalid rst format - D000
-    - lines should not be longer than 79 characters - D001
-      - RST exception: line with no whitespace except in the beginning
-      - RST exception: lines with http or https urls
-      - RST exception: literal blocks
-      - RST exception: rst target directives
-    - no trailing whitespace - D002
-    - no tabulation for indentation - D003
-    - no carriage returns (use unix newlines) - D004
-    - no newline at end of file - D005
+   -  invalid RST format - D000
+   -  lines should not be longer than 79 characters - D001
+      -  RST exception: line with no whitespace except in the beginning
+      -  RST exception: lines with http or https urls
+      -  RST exception: literal blocks
+      -  RST exception: rst target directives
+   -  no trailing whitespace - D002
+   -  no tabulation for indentation - D003
+      -  All RST files use an indentation of 3 spaces
+   -  no carriage returns (use unix newlines) - D004
+   -  no newline at end of file - D005
 """
 
 import argparse
@@ -172,7 +173,7 @@ def fetch_checks(cfg):
     base = [
         checks.CheckValidity(cfg),
         checks.CheckTrailingWhitespace(cfg),
-        checks.CheckIndentationNoTab(cfg),
+        checks.CheckIndentation(cfg),
         checks.CheckCarriageReturn(cfg),
         checks.CheckMaxLineLength(cfg),
         checks.CheckNewlineEndOfFile(cfg),

--- a/src/doc8/tests/test_checks.py
+++ b/src/doc8/tests/test_checks.py
@@ -29,14 +29,14 @@ class TestTrailingWhitespace(unittest.TestCase):
         self.assertIn(code, check.REPORTS)
 
 
-class TestTabIndentation(unittest.TestCase):
-    def test_tabs(self):
-        lines = ["    b", "\tabc", "efg", "\t\tc"]
-        check = checks.CheckIndentationNoTab({})
+class TestIndentation(unittest.TestCase):
+    def test_indentation(self):
+        lines = ["   b", "\tabc", "efg", "\t\tc", "  b", "    b"]
+        check = checks.CheckIndentation({})
         errors = []
         for line in lines:
             errors.extend(check.report_iter(line))
-        self.assertEqual(2, len(errors))
+        self.assertEqual(4, len(errors))
         (code, msg) = errors[0]
         self.assertIn(code, check.REPORTS)
 

--- a/src/doc8/tests/test_main.py
+++ b/src/doc8/tests/test_main.py
@@ -22,7 +22,7 @@ Total files ignored = 0
 Total accumulated errors = 2
 Detailed error counts:
     - doc8.checks.CheckCarriageReturn = 0
-    - doc8.checks.CheckIndentationNoTab = 0
+    - doc8.checks.CheckIndentation = 0
     - doc8.checks.CheckMaxLineLength = 0
     - doc8.checks.CheckNewlineEndOfFile = 1
     - doc8.checks.CheckTrailingWhitespace = 1
@@ -42,7 +42,7 @@ Validating {path}/invalid.rst (utf-8, 10 chars, 1 lines)
   Running check 'doc8.checks.CheckValidity'
   Running check 'doc8.checks.CheckTrailingWhitespace'
     - {path}/invalid.rst:1: D002 Trailing whitespace
-  Running check 'doc8.checks.CheckIndentationNoTab'
+  Running check 'doc8.checks.CheckIndentation'
   Running check 'doc8.checks.CheckCarriageReturn'
   Running check 'doc8.checks.CheckMaxLineLength'
   Running check 'doc8.checks.CheckNewlineEndOfFile'
@@ -53,7 +53,7 @@ Total files ignored = 0
 Total accumulated errors = 2
 Detailed error counts:
     - doc8.checks.CheckCarriageReturn = 0
-    - doc8.checks.CheckIndentationNoTab = 0
+    - doc8.checks.CheckIndentation = 0
     - doc8.checks.CheckMaxLineLength = 0
     - doc8.checks.CheckNewlineEndOfFile = 1
     - doc8.checks.CheckTrailingWhitespace = 1
@@ -69,7 +69,7 @@ Total files ignored = 0
 Total accumulated errors = 2
 Detailed error counts:
     - doc8.checks.CheckCarriageReturn = 0
-    - doc8.checks.CheckIndentationNoTab = 0
+    - doc8.checks.CheckIndentation = 0
     - doc8.checks.CheckMaxLineLength = 0
     - doc8.checks.CheckNewlineEndOfFile = 1
     - doc8.checks.CheckTrailingWhitespace = 1


### PR DESCRIPTION
> All reST files use an indentation of 3 spaces; no tabs are allowed.

https://devguide.python.org/documentation/markup/#use-of-whitespace

Personally, I also find 3 spaces better in RST files. Aligns directives, bullets, and enumerated lists.
```rst
.. directive::

   content

-  item1
-  item2

   -  subitem

#. item1
#. item2

   a. subitem1
   #. subitem2
```

These items may need 4 spaces, but they can be avoided. And 3 is suited for `directives`
```rst
(1) Use 1. ..

    (a) .. or a)

10. hopefully you can auto-enumerate..
11. ..or do not need sub-items.
```