### PR TITLE
Add ignore for `path-substitutions` in `include` directive

### DIFF
--- a/src/doc8/checks.py
+++ b/src/doc8/checks.py
@@ -119,6 +119,10 @@ class CheckValidity(ContentCheck):
             re.MULTILINE,
         ),
         re.compile(
+            r'^Error in \"include\" directive\:\nunknown option: "path-substitutions".',
+            re.MULTILINE,
+        ),
+        re.compile(
             r'^PEP number must be a number from 0 to 9999; "\d{1,4}#[^"]*" is invalid.',
         ),
     ]


### PR DESCRIPTION
I am the author of [`sphinx-substitution-extensions`](https://github.com/adamtheturtle/sphinx-substitution-extensions).

This enables substitutions in existing Sphinx / docutils directives by adding new options.

There is already an ignore in this project for `code-block` (just above the added ignore). I wish to add support for `include` to my extension, at https://github.com/adamtheturtle/sphinx-substitution-extensions/pull/1265, but there is a conflict with `doc8`.